### PR TITLE
append ${EXT} to the executable name when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 GO=go
+EXT=
 
 all: build
 
 build:
-	${GO} build -v -o s3Importer ./plugin/importer
-	${GO} build -v -o s3Exporter ./plugin/exporter
-	${GO} build -v -o s3Storage ./plugin/storage
+	${GO} build -v -o s3Importer${EXT} ./plugin/importer
+	${GO} build -v -o s3Exporter${EXT} ./plugin/exporter
+	${GO} build -v -o s3Storage${EXT} ./plugin/storage
 
 clean:
 	rm -f s3Importer s3Exporter s3Storage s3-*.ptar


### PR DESCRIPTION
mostly for windows, where we need to append .exe to the file name. EXT will be set by plakar build.