### PR TITLE
storage: pledge "stdio rpath inet dns"; with unveil too

### DIFF
--- a/pledge.go
+++ b/pledge.go
@@ -1,0 +1,6 @@
+//go:build !openbsd
+
+package s3
+
+func Unveil(string, string) error { return nil }
+func Pledge(string) error         { return nil }

--- a/pledge_openbsd.go
+++ b/pledge_openbsd.go
@@ -1,0 +1,13 @@
+//go:build openbsd
+
+package s3
+
+import "golang.org/x/sys/unix"
+
+func Unveil(path, perm string) error {
+	return unix.Unveil(path, perm)
+}
+
+func Pledge(promises string) error {
+	return unix.PledgePromises(promises)
+}

--- a/plugin/storage/main.go
+++ b/plugin/storage/main.go
@@ -1,12 +1,34 @@
 package main
 
 import (
+	"log"
 	"os"
+	"runtime"
 
 	sdk "github.com/PlakarKorp/go-kloset-sdk"
+	s3 "github.com/PlakarKorp/integration-s3"
 	"github.com/PlakarKorp/integration-s3/storage"
 )
 
 func main() {
+	// golang stdlib tries to open cert files at "well known"
+	// locations.  On OpenBSD, we only really have
+	// /etc/ssl/cert.pem, so that's a safe guess, but attempt to
+	// respect SSL_CERT_FILE if set.
+	if runtime.GOOS == "openbsd" {
+		cert, ok := os.LookupEnv("SSL_CERT_FILE")
+		if !ok {
+			cert = "/etc/ssl/cert.pem"
+			os.Setenv("SSL_CERT_FILE", cert)
+		}
+
+		if err := s3.Unveil(cert, "r"); err != nil {
+			log.Fatalln("unveil /etc/ssl/cert.pem:", err)
+		}
+		if err := s3.Pledge("stdio rpath inet dns"); err != nil {
+			log.Fatalln("pledge:", err)
+		}
+	}
+
 	sdk.EntrypointStorage(os.Args, storage.NewStore)
 }


### PR DESCRIPTION
The s3 storage ideally only needs to do stdio and open sockets.  Since there's TLS in the mix we also need the golang stdlib to access the right cert.pem.

Here the thing gets a little bit more complicated.  The stdlib tries to open cert.pem at "well-known" locations, including paths that don't make sense on OpenBSD (e.g. /usr/local/etc/ssl/cert.pem).

To prevent that, set SSL_CERT_FILE to /etc/ssl/cert.pem, but only if it's not already set, and unveil that path.

This is just to give an idea.  If we like it I can do the same for the importer and exporter.  (in this precise moment I don't have a good setup for an s3 importer, that's why it's not in the diff.)