### PR TITLE
manifest: bump version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,7 +4,7 @@ description: Integration providing storage, import and export capabilities to an
 homepage: https://github.com/PlakarKorp/integration-s3
 license: ISC
 api_version: v1.0.0
-version: v1.0.0
+version: v1.0.5
 connectors:
 - type: importer
   executable: s3Importer


### PR DESCRIPTION
was forgotten last time, so 1.0.5 be it.  no functional changes.