### PR TITLE
Support new option sse_customer_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The configuration parameters are as follows:
 - `tls_insecure_no_verify` (optional): If set to `true`, disables certificate verification (defaults to `false`)
 - `secret_access_key` (required): AWS secret access key
 - `virtual_host` (optional): whether the host name includes the bucket name (defaults to `false`)
+- `sse_customer_key` (optional): base64-encoded 256-bit (32-byte) AES-256 customer-provided key for SSE-C server-side encryption
 
 For S3-compatible storage providers, you may also need to specify:
 - `storage_class`: The storage class to use (e.g., `STANDARD`, `GLACIER`)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -18,6 +18,7 @@ package exporter
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"path"
@@ -29,6 +30,7 @@ import (
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,6 +41,7 @@ type S3Exporter struct {
 	host        string
 	bucket      string
 	restoreDir  string
+	ssec        encrypt.ServerSide
 }
 
 func init() {
@@ -115,6 +118,18 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	var ssec encrypt.ServerSide
+	if value, ok := config["sse_customer_key"]; ok {
+		keyBytes, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)
+		}
+		ssec, err = encrypt.NewSSEC(keyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: %w", err)
+		}
+	}
+
 	parsed, err := url.Parse(target)
 	if err != nil {
 		return nil, err
@@ -155,6 +170,7 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		host:        host,
 		bucket:      bucket,
 		restoreDir:  restoreDir,
+		ssec:        ssec,
 	}, nil
 }
 
@@ -189,7 +205,7 @@ func (p *S3Exporter) Export(ctx context.Context, records <-chan *connectors.Reco
 		g.Go(func() error {
 			objname := strings.TrimLeft(path.Join(p.restoreDir, record.Pathname), "/")
 			_, err := p.minioClient.PutObject(ctx, p.bucket, objname,
-				record.Reader, record.FileInfo.Lsize, minio.PutObjectOptions{})
+				record.Reader, record.FileInfo.Lsize, minio.PutObjectOptions{ServerSideEncryption: p.ssec})
 			results <- record.Error(err)
 			return nil
 		})

--- a/exporter/schema.json
+++ b/exporter/schema.json
@@ -39,6 +39,11 @@
       "type": "boolean",
       "default": false,
       "description": "Whether the hostname in location includes the bucket name as well."
+    },
+    "sse_customer_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Base64-encoded 256-bit (32-byte) customer-provided AES-256 key for SSE-C server-side encryption"
     }
   }
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -18,6 +18,7 @@ package importer
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/importer"
@@ -40,6 +42,7 @@ type S3Importer struct {
 	bucket  string
 	host    string
 	scanDir string
+	ssec    encrypt.ServerSide
 }
 
 func init() {
@@ -114,6 +117,18 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	var ssec encrypt.ServerSide
+	if value, ok := config["sse_customer_key"]; ok {
+		keyBytes, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)
+		}
+		ssec, err = encrypt.NewSSEC(keyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: %w", err)
+		}
+	}
+
 	parsed, err := url.Parse(target)
 	if err != nil {
 		return nil, err
@@ -145,6 +160,7 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		scanDir:     scanDir,
 		minioClient: conn,
 		host:        host,
+		ssec:        ssec,
 	}, nil
 }
 
@@ -193,7 +209,7 @@ func (p *S3Importer) Import(ctx context.Context, records chan<- *connectors.Reco
 		}
 
 		records <- connectors.NewRecord("/"+object.Key, "", fi, nil, func() (io.ReadCloser, error) {
-			return p.minioClient.GetObject(ctx, p.bucket, object.Key, minio.GetObjectOptions{})
+			return p.minioClient.GetObject(ctx, p.bucket, object.Key, minio.GetObjectOptions{ServerSideEncryption: p.ssec})
 		})
 	}
 

--- a/importer/schema.json
+++ b/importer/schema.json
@@ -39,6 +39,11 @@
       "type": "boolean",
       "default": false,
       "description": "Whether the hostname in location includes the bucket name as well."
+    },
+    "sse_customer_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Base64-encoded 256-bit (32-byte) customer-provided AES-256 key for SSE-C server-side encryption"
     }
   }
 }

--- a/storage/schema.json
+++ b/storage/schema.json
@@ -54,6 +54,11 @@
       "type": "boolean",
       "default": false,
       "description": "Whether the hostname in location includes the bucket name as well."
+    },
+    "sse_customer_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Base64-encoded 256-bit (32-byte) customer-provided AES-256 key for SSE-C server-side encryption"
     }
   }
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -36,6 +37,7 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 )
 
 type Store struct {
@@ -44,6 +46,7 @@ type Store struct {
 	bucket       string
 	prefixDir    string
 	storageClass string
+	ssec         encrypt.ServerSide
 
 	bufPool sync.Pool
 
@@ -104,6 +107,18 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		virtualHost = tmp
 	}
 
+	var ssec encrypt.ServerSide
+	if value, ok := storeConfig["sse_customer_key"]; ok {
+		keyBytes, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)
+		}
+		ssec, err = encrypt.NewSSEC(keyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_customer_key: %w", err)
+		}
+	}
+
 	u, err := url.Parse(storeConfig["location"])
 	if err != nil {
 		return nil, fmt.Errorf("parse location: %w", err)
@@ -153,6 +168,7 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		bucket:       bucket,
 		prefixDir:    prefixDir,
 		storageClass: storageClass,
+		ssec:         ssec,
 
 		bufPool: sync.Pool{
 			New: func() any {
@@ -164,8 +180,9 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 			// Some providers (eg. BlackBlaze) return the error
 			// "Unsupported header 'x-amz-checksum-algorithm'" if SendContentMd5
 			// is not set.
-			StorageClass:   storageClass,
-			SendContentMd5: true,
+			StorageClass:         storageClass,
+			SendContentMd5:       true,
+			ServerSideEncryption: ssec,
 		},
 	}, nil
 }
@@ -186,7 +203,7 @@ func (s *Store) Create(ctx context.Context, config []byte) error {
 		}
 	}
 
-	_, err = s.minioClient.StatObject(ctx, s.bucket, s.realpath("CONFIG"), minio.StatObjectOptions{})
+	_, err = s.minioClient.StatObject(ctx, s.bucket, s.realpath("CONFIG"), minio.StatObjectOptions{ServerSideEncryption: s.ssec})
 	if err != nil {
 		if minio.ToErrorResponse(err).Code != "NoSuchKey" {
 			return fmt.Errorf("stat object CONFIG: %w", err)
@@ -224,7 +241,7 @@ func (s *Store) Open(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("bucket does not exist")
 	}
 
-	object, err := s.minioClient.GetObject(ctx, s.bucket, s.realpath("CONFIG"), minio.GetObjectOptions{})
+	object, err := s.minioClient.GetObject(ctx, s.bucket, s.realpath("CONFIG"), minio.GetObjectOptions{ServerSideEncryption: s.ssec})
 	if err != nil {
 		return nil, fmt.Errorf("error getting object: %w", err)
 	}
@@ -359,7 +376,7 @@ func (s *Store) Get(ctx context.Context, res storage.StorageResource, mac object
 		return nil, errors.ErrUnsupported
 	}
 
-	object, err := s.minioClient.GetObject(ctx, s.bucket, path, minio.GetObjectOptions{})
+	object, err := s.minioClient.GetObject(ctx, s.bucket, path, minio.GetObjectOptions{ServerSideEncryption: s.ssec})
 	if err != nil {
 		return nil, fmt.Errorf("get %s object: %w", res, err)
 	}


### PR DESCRIPTION
Tested on Scaleway following this doc: https://www.scaleway.com/en/docs/object-storage/api-cli/enable-sse-c/

1/ Create the SSE-C:

```
openssl rand -out ssec.key 32
ENCRYPTION_KEY=$(cat ssec.key | base64)
KEY_DIGEST=$(openssl dgst -md5 -binary ssec.key | base64)
```

2/ Try to upload an object using s3api

```
aws s3api --profile plakar-scw-staging put-object --bucket jcastets-test-sse --key LICENSE --body LICENSE --sse-customer-algorithm AES256 --sse-customer-key $ENCRYPTION_KEY --sse-customer-key-md5 $KEY_DIGEST
```

3/ Try to back it up

```
./plakar at ./toto backup -o sse_customer_key='kaLwn4YpG5y0g2oV2khIdlbnHoieKZlJt1eZq9hkU2A=' @scw-staging-jcastets-test-sse
```

4/ Try to restore it

```
./plakar at ./toto restore -to @scw-staging-jcastets-test-sse b3366bce
```

5/ Try to retrieve the file without specifying the key

```
aws s3api --profile plakar-scw-staging get-object --bucket jcastets-test-sse --key Dockerfile ./LICENSE.out

aws: [ERROR]: An error occurred (InvalidRequest) when calling the GetObject operation: The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.
```

6/ Try to retrieve it with the key:

```
aws s3api --profile plakar-scw-staging get-object --bucket jcastets-test-sse --key Dockerfile ./LICENSE.out --sse-customer-algorithm AES256 --sse-customer-key "$ENCRYPTION_KEY" --sse-customer-key-md5 "$KEY_DIGEST"                                                                                                                                                          {
    "AcceptRanges": "bytes",
    "LastModified": "2026-05-06T16:28:26+00:00",
    "ContentLength": 1089,
    "ETag": "\"4ead7c07afd9c03d9d1611d41468b06f\"",
    "ContentType": "application/octet-stream",
    "Metadata": {},
    "SSECustomerAlgorithm": "AES256",
    "SSECustomerKeyMD5": "aMQnXVs9vKSmbLn/VWiBeQ=="
}

# LICENSE.out contains the correct perms
```
