### PR TITLE
all: treat empty sse_customer_key as unset

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -119,7 +119,7 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 	}
 
 	var ssec encrypt.ServerSide
-	if value, ok := config["sse_customer_key"]; ok {
+	if value, ok := config["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -118,7 +118,7 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 	}
 
 	var ssec encrypt.ServerSide
-	if value, ok := config["sse_customer_key"]; ok {
+	if value, ok := config["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -108,7 +108,7 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 	}
 
 	var ssec encrypt.ServerSide
-	if value, ok := storeConfig["sse_customer_key"]; ok {
+	if value, ok := storeConfig["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid sse_customer_key: must be base64-encoded: %w", err)


### PR DESCRIPTION
Fixes plakar control plane which always passes an empty string to the plugin, returning an error because an empty string is not a valid SSE customer key.