### PR TITLE
support providing root and port from config

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -118,6 +118,16 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	var port string
+	if tmp, ok := config["port"]; ok {
+		port = tmp
+	}
+
+	var root string
+	if tmp, ok := config["root"]; ok {
+		root = tmp
+	}
+
 	var ssec encrypt.ServerSide
 	if value, ok := config["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
@@ -135,6 +145,10 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		return nil, err
 	}
 
+	if parsed.Port() == "" && port != "" {
+		parsed.Host = fmt.Sprintf("%s:%s", parsed.Host, port)
+	}
+
 	var bucket, restoreDir, host string
 	if virtualHost {
 		bucket, host, _ = strings.Cut(parsed.Host, ".")
@@ -143,8 +157,13 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
 		}
 	} else {
-		bucket, restoreDir, _ = strings.Cut(parsed.RequestURI()[1:], "/")
 		host = parsed.Host
+
+		source := parsed.RequestURI()
+		if root != "" {
+			source = root
+		}
+		bucket, restoreDir, _ = strings.Cut(strings.TrimPrefix(source, "/"), "/")
 	}
 
 	if bucket == "" || host == "" {

--- a/exporter/schema.json
+++ b/exporter/schema.json
@@ -15,6 +15,18 @@
       "description": "S3 location URI: s3://<endpoint>/<bucket>/<optional-prefix>",
       "pattern": "^s3://[^/]+/[^/]+(/.*)?$"
     },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "TCP/UDP port number"
+    },
+    "root": {
+      "type": "string",
+      "default": "/",
+      "pattern": "^/",
+      "description": "bucket path prefix to use"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -117,6 +117,16 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	var port string
+	if tmp, ok := config["port"]; ok {
+		port = tmp
+	}
+
+	var root string
+	if tmp, ok := config["root"]; ok {
+		root = tmp
+	}
+
 	var ssec encrypt.ServerSide
 	if value, ok := config["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
@@ -134,6 +144,10 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		return nil, err
 	}
 
+	if parsed.Port() == "" && port != "" {
+		parsed.Host = fmt.Sprintf("%s:%s", parsed.Host, port)
+	}
+
 	var bucket, scanDir, host string
 	if virtualHost {
 		bucket, host, _ = strings.Cut(parsed.Host, ".")
@@ -142,8 +156,13 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
 		}
 	} else {
-		bucket, scanDir, _ = strings.Cut(parsed.RequestURI()[1:], "/")
 		host = parsed.Host
+
+		source := parsed.RequestURI()
+		if root != "" {
+			source = root
+		}
+		bucket, scanDir, _ = strings.Cut(strings.TrimPrefix(source, "/"), "/")
 	}
 
 	if bucket == "" || host == "" {

--- a/importer/schema.json
+++ b/importer/schema.json
@@ -15,6 +15,18 @@
       "description": "S3 location URI: s3://<endpoint>/<bucket>/<optional-prefix>",
       "pattern": "^s3://[^/]+/[^/]+(/.*)?$"
     },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "TCP/UDP port number"
+    },
+    "root": {
+      "type": "string",
+      "default": "/",
+      "pattern": "^/",
+      "description": "bucket path prefix to use"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/storage/schema.json
+++ b/storage/schema.json
@@ -15,6 +15,18 @@
       "description": "S3 location URI: s3://<endpoint>/<bucket>/<optional-prefix>",
       "pattern": "^s3://[^/]+/[^/]+(/.*)?$"
     },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "TCP/UDP port number"
+    },
+    "root": {
+      "type": "string",
+      "default": "/",
+      "pattern": "^/",
+      "description": "bucket path prefix to use"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -107,6 +107,16 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		virtualHost = tmp
 	}
 
+	var port string
+	if tmp, ok := storeConfig["port"]; ok {
+		port = tmp
+	}
+
+	var root string
+	if tmp, ok := storeConfig["root"]; ok {
+		root = tmp
+	}
+
 	var ssec encrypt.ServerSide
 	if value, ok := storeConfig["sse_customer_key"]; ok && value != "" {
 		keyBytes, err := base64.StdEncoding.DecodeString(value)
@@ -124,6 +134,10 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		return nil, fmt.Errorf("parse location: %w", err)
 	}
 
+	if u.Port() == "" && port != "" {
+		u.Host = fmt.Sprintf("%s:%s", u.Host, port)
+	}
+
 	var bucket, prefixDir, host string
 	if virtualHost {
 		bucket, host, _ = strings.Cut(u.Host, ".")
@@ -132,8 +146,14 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
 		}
 	} else {
-		bucket, prefixDir, _ = strings.Cut(u.RequestURI()[1:], "/")
+
 		host = u.Host
+
+		source := u.RequestURI()
+		if root != "" {
+			source = root
+		}
+		bucket, prefixDir, _ = strings.Cut(strings.TrimPrefix(source, "/"), "/")
 	}
 
 	if bucket == "" || host == "" {


### PR DESCRIPTION
This PR makes port and root path (bucket + prefix) configurable from config if provided.

With this, a bucket that's configured as follows today:

```
    minio:
        access_key: minioadmin
        location: s3://localhost:9000/bleh
        secret_access_key: minioadmin
        use_tls: false
```

can now also be configured as:

```
    minio:
        access_key: minioadmin
        location: s3://localhost
        root: /bleh
        secret_access_key: minioadmin
        port: 9000
        use_tls: false
```