### PR TITLE
use short bucket notation + endpoint, fixes virtual host handling

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+func SplitVirtualHost(hostname, endpoint string) (bucket, host string, err error) {
+	hostname = strings.TrimSuffix(hostname, ".") // foo.bar.com. -> foo.bar.com
+
+	// sanitize the endpoint
+	// we want to be able to compare it with the end of the hostname,
+	// so we need to remove any protocol, trailing slash and leading dot.
+	endpoint = strings.TrimSpace(endpoint)
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	endpoint = strings.TrimPrefix(endpoint, ".")
+
+	if endpoint == "" {
+		return "", "", fmt.Errorf("empty endpoint")
+	}
+
+	bucket = strings.TrimSuffix(hostname, "."+endpoint) // foo.bar.com. -> foo.bar.com
+
+	return bucket, endpoint, nil
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -119,10 +119,7 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
-	endpoint := ""
-	if value, ok := config["endpoint"]; ok {
-		endpoint = value
-	}
+	endpoint := config["endpoint"]
 
 	var port string
 	if tmp, ok := config["port"]; ok {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/PlakarKorp/integration-s3/common"
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/exporter"
 	"github.com/PlakarKorp/kloset/location"
@@ -118,6 +119,11 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	endpoint := ""
+	if value, ok := config["endpoint"]; ok {
+		endpoint = value
+	}
+
 	var port string
 	if tmp, ok := config["port"]; ok {
 		port = tmp
@@ -151,15 +157,26 @@ func NewS3Exporter(ctx context.Context, opts *connectors.Options, name string, c
 
 	var bucket, restoreDir, host string
 	if virtualHost {
-		bucket, host, _ = strings.Cut(parsed.Host, ".")
-		restoreDir = strings.TrimPrefix(parsed.Path, "/")
-		if host == "" {
-			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
+		if endpoint == "" {
+			return nil, fmt.Errorf("missing endpoint when virtual_host=true")
 		}
+
+		bucket, host, err = common.SplitVirtualHost(parsed.Host, endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		restoreDir = strings.TrimPrefix(parsed.Path, "/")
 	} else {
+		if endpoint != "" {
+			if parsed.Host != endpoint {
+				parsed.Path = path.Join(parsed.Host, parsed.Path)
+				parsed.Host = endpoint
+			}
+		}
 		host = parsed.Host
 
-		source := parsed.RequestURI()
+		source := parsed.Path
 		if root != "" {
 			source = root
 		}

--- a/exporter/schema.json
+++ b/exporter/schema.json
@@ -27,6 +27,12 @@
       "pattern": "^/",
       "description": "bucket path prefix to use"
     },
+    "endpoint": {
+      "type": "string",
+      "default": "",
+      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
+      "description": "S3 endpoint URL"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/exporter/schema.json
+++ b/exporter/schema.json
@@ -30,7 +30,6 @@
     "endpoint": {
       "type": "string",
       "default": "",
-      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
       "description": "S3 endpoint URL"
     },
     "access_key": {

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 
+	"github.com/PlakarKorp/integration-s3/common"
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/importer"
 	"github.com/PlakarKorp/kloset/location"
@@ -117,6 +118,11 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
+	endpoint := ""
+	if value, ok := config["endpoint"]; ok {
+		endpoint = value
+	}
+
 	var port string
 	if tmp, ok := config["port"]; ok {
 		port = tmp
@@ -150,15 +156,26 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 
 	var bucket, scanDir, host string
 	if virtualHost {
-		bucket, host, _ = strings.Cut(parsed.Host, ".")
-		scanDir = strings.TrimPrefix(parsed.Path, "/")
-		if host == "" {
-			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
+		if endpoint == "" {
+			return nil, fmt.Errorf("missing endpoint when virtual_host=true")
 		}
+
+		bucket, host, err = common.SplitVirtualHost(parsed.Host, endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		scanDir = strings.TrimPrefix(parsed.Path, "/")
 	} else {
+		if endpoint != "" {
+			if parsed.Host != endpoint {
+				parsed.Path = path.Join(parsed.Host, parsed.Path)
+				parsed.Host = endpoint
+			}
+		}
 		host = parsed.Host
 
-		source := parsed.RequestURI()
+		source := parsed.Path
 		if root != "" {
 			source = root
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -118,10 +118,7 @@ func NewS3Importer(ctx context.Context, opts *connectors.Options, name string, c
 		virtualHost = tmp
 	}
 
-	endpoint := ""
-	if value, ok := config["endpoint"]; ok {
-		endpoint = value
-	}
+	endpoint := config["endpoint"]
 
 	var port string
 	if tmp, ok := config["port"]; ok {

--- a/importer/schema.json
+++ b/importer/schema.json
@@ -27,6 +27,12 @@
       "pattern": "^/",
       "description": "bucket path prefix to use"
     },
+    "endpoint": {
+      "type": "string",
+      "default": "",
+      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
+      "description": "S3 endpoint URL"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/importer/schema.json
+++ b/importer/schema.json
@@ -30,7 +30,6 @@
     "endpoint": {
       "type": "string",
       "default": "",
-      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
       "description": "S3 endpoint URL"
     },
     "access_key": {

--- a/storage/schema.json
+++ b/storage/schema.json
@@ -27,6 +27,12 @@
       "pattern": "^/",
       "description": "bucket path prefix to use"
     },
+    "endpoint": {
+      "type": "string",
+      "default": "",
+      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
+      "description": "S3 endpoint URL"
+    },
     "access_key": {
       "type": "string",
       "minLength": 1,

--- a/storage/schema.json
+++ b/storage/schema.json
@@ -30,7 +30,6 @@
     "endpoint": {
       "type": "string",
       "default": "",
-      "pattern": "^(https?:\\/\\/)?(([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|localhost)(:\\d+)?(\\/.*)?$",
       "description": "S3 endpoint URL"
     },
     "access_key": {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -108,10 +108,7 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		virtualHost = tmp
 	}
 
-	endpoint := ""
-	if value, ok := storeConfig["endpoint"]; ok {
-		endpoint = value
-	}
+	endpoint := storeConfig["endpoint"]
 
 	var port string
 	if tmp, ok := storeConfig["port"]; ok {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/PlakarKorp/integration-s3/common"
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
@@ -107,6 +108,11 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		virtualHost = tmp
 	}
 
+	endpoint := ""
+	if value, ok := storeConfig["endpoint"]; ok {
+		endpoint = value
+	}
+
 	var port string
 	if tmp, ok := storeConfig["port"]; ok {
 		port = tmp
@@ -140,16 +146,26 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 
 	var bucket, prefixDir, host string
 	if virtualHost {
-		bucket, host, _ = strings.Cut(u.Host, ".")
-		prefixDir = strings.TrimPrefix(u.Path, "/")
-		if host == "" {
-			return nil, fmt.Errorf("failed to extract bucket name from URL (maybe virtual_host needs to be disable?)")
+		if endpoint == "" {
+			return nil, fmt.Errorf("missing endpoint when virtual_host=true")
 		}
-	} else {
 
+		bucket, host, err = common.SplitVirtualHost(u.Host, endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		prefixDir = strings.TrimPrefix(u.Path, "/")
+	} else {
+		if endpoint != "" {
+			if u.Host != endpoint {
+				u.Path = path.Join(u.Host, u.Path)
+				u.Host = endpoint
+			}
+		}
 		host = u.Host
 
-		source := u.RequestURI()
+		source := u.Path
 		if root != "" {
 			source = root
 		}
@@ -183,6 +199,9 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		Secure:    useSsl,
 		Transport: transport,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create minio client: %w", err)
+	}
 
 	client.SetAppInfo("plakar", "v1.1.0")
 


### PR DESCRIPTION
location should support short bucket notation:

s3://bucket (w/ endpoint=s3.fr-par.scaleway.cloud)

This is the way most CLI tools work (s3, s5_cmd, warp, mc, ...) and incidentally it fixes the vhost resolving of dotted buckets.

I fixed in a backwards compatible way, so endpoint is stripped from location if long address notation is used. tested with scaleway in vhost mode, short and long notations, as well as minio in short and long notations (no vhost).

please test !