### PR TITLE
fix S3 medata lost during backup #1967

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -19,6 +19,7 @@ package exporter
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"path"
@@ -227,8 +228,21 @@ func (p *S3Exporter) Export(ctx context.Context, records <-chan *connectors.Reco
 
 		g.Go(func() error {
 			objname := strings.TrimLeft(path.Join(p.restoreDir, record.Pathname), "/")
+			var objectInfo minio.ObjectInfo
+			if len(record.ExtendedAttributes) > 0 {
+				if err := json.Unmarshal([]byte(record.ExtendedAttributes[0]), &objectInfo); err != nil {
+					objectInfo.UserTags = nil
+					objectInfo.UserMetadata = nil
+				}
+			}
+
 			_, err := p.minioClient.PutObject(ctx, p.bucket, objname,
-				record.Reader, record.FileInfo.Lsize, minio.PutObjectOptions{ServerSideEncryption: p.ssec})
+				record.Reader, record.FileInfo.Lsize, minio.PutObjectOptions{
+					ServerSideEncryption: p.ssec,
+					ContentType:          objectInfo.ContentType,
+					UserTags:             objectInfo.UserTags,
+					UserMetadata:         objectInfo.UserMetadata,
+				})
 			results <- record.Error(err)
 			return nil
 		})

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -19,6 +19,7 @@ package importer
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -223,6 +224,10 @@ func (p *S3Importer) Import(ctx context.Context, records chan<- *connectors.Reco
 			continue
 		}
 
+		stat, err := p.minioClient.StatObject(ctx, p.bucket, object.Key, minio.GetObjectOptions{ServerSideEncryption: p.ssec})
+		if err != nil {
+			continue
+		}
 		fi := objects.FileInfo{
 			Lname:    path.Base("/" + object.Key),
 			Lsize:    object.Size,
@@ -231,7 +236,13 @@ func (p *S3Importer) Import(ctx context.Context, records chan<- *connectors.Reco
 			Ldev:     1,
 		}
 
-		records <- connectors.NewRecord("/"+object.Key, "", fi, nil, func() (io.ReadCloser, error) {
+		var xattr []string
+		xattrStr, err := json.Marshal(stat)
+		if err == nil {
+			xattr = append(xattr, string(xattrStr))
+		}
+
+		records <- connectors.NewRecord("/"+object.Key, "", fi, xattr, func() (io.ReadCloser, error) {
 			return p.minioClient.GetObject(ctx, p.bucket, object.Key, minio.GetObjectOptions{ServerSideEncryption: p.ssec})
 		})
 	}


### PR DESCRIPTION
Hello,
Here is a proposal to address the issue of backup and restore S3 metadata.
The solution isn’t perfect at this point because it increases the backup time, as it’s necessary to retrieve information for each S3 object while traversing the directory tree.